### PR TITLE
fix error bound syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Check [Discord.js v12 documentation](https://v12.discordjs.guide/creating-your-b
 
 9. Use the `!debugtime SCORE`, where SCORE is the score on the rating screen as shown below (example: `!debugtime 113593`):
 
-![debug 2](https://i.ibb.co/pfK6ZQT/debugtime2.PNG)
+![debug 2](https://i.ibb.co/1ZfR2Jf/debugtime2.png)
 
 If needed, click the individual links on the debug message to see the exact math equation use (cross reference with [Longer Math Explanation](https://github.com/solderq35/time-calc-under-5/blob/main/README.md#mathematics-code-explanation) link at bottom):
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Check [Discord.js v12 documentation](https://v12.discordjs.guide/creating-your-b
 
 9. Use the `!debugtime SCORE`, where SCORE is the score on the rating screen as shown below (example: `!debugtime 113593`):
 
-![debug 2](https://i.ibb.co/1ZfR2Jf/debugtime2.png)
+![debug 2](https://i.ibb.co/YtGzhDM/debugtime2.png)
 
 If needed, click the individual links on the debug message to see the exact math equation use (cross reference with [Longer Math Explanation](https://github.com/solderq35/time-calc-under-5/blob/main/README.md#mathematics-code-explanation) link at bottom):
 
-![googleCalc](https://i.ibb.co/y4F9Qp5/googlecalc.png)
+![googleCalc](https://i.ibb.co/th5bSCX/googlecalc.png)

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ Check [Discord.js v12 documentation](https://v12.discordjs.guide/creating-your-b
 
 7. As you can see, the bot returns a few viable solutions. One of them (8.981) is within a second of the 8 seconds value shown on the rating screen, so this is the milliseconds value we are looking for.
 
-8. In case of rounding errors, you will get a warning, as shown below (example: `!time 113593`):
+8. In case of rounding errors, you will get a warning, as shown below (example: `!time 204667`):
 
-![debug 1](https://i.ibb.co/mDgFDLH/debugtime1.png)
+![debug 1](https://i.ibb.co/G3hRtXS/debugtime1.png)
 
-9. Use the `!debugtime SCORE`, where SCORE is the score on the rating screen as shown below (example: `!debugtime 113593`):
+9. Use the `!debugtime SCORE`, where SCORE is the score on the rating screen as shown below (example: `!debugtime 204667`):
 
 ![debug 2](https://i.ibb.co/YtGzhDM/debugtime2.png)
 

--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ client.on("messageCreate", function (msgInput) {
         }
         let debug_result = `- Original Time Calc: [${formatted_result}](<https://www.google.com/search?q=%28210000+-+%28${parseFloat(
           score
-        )}+*+100000+%2F+${base_M}%29%29+*+%283+%2F+400%29>)\n  - Time Calc Error Range: ([${formatted_lower_bound}](<https://www.google.com/search?q=%28210000+-+%28${parseFloat(
+        )}+*+100000+%2F+${base_M}%29%29+*+%283+%2F+400%29>)\n  - Time Calc Error Range: [[${formatted_lower_bound}](<https://www.google.com/search?q=%28210000+-+%28${parseFloat(
           score + 0.5
         )}+*+100000+%2F+${base_M}%29%29+*+%283+%2F+400%29>), [${formatted_higher_bound}](<https://www.google.com/search?q=%28210000+-+%28${parseFloat(
           score - 0.5

--- a/index.js
+++ b/index.js
@@ -99,11 +99,11 @@ client.on("messageCreate", function (msgInput) {
         }
         let debug_result = `- Original Time Calc: [${formatted_result}](<https://www.google.com/search?q=%28210000+-+%28${parseFloat(
           score
-        )}+*+100000+%2F+${base_M}%29%29+*+%283+%2F+400%29>)\n  - Time Calc Error Range: [[${formatted_lower_bound}](<https://www.google.com/search?q=%28210000+-+%28${parseFloat(
+        )}+*+100000+%2F+${base_M}%29%29+*+%283+%2F+400%29>)\n  - Time Calc Error Range: ([${formatted_lower_bound}](<https://www.google.com/search?q=%28210000+-+%28${parseFloat(
           score + 0.5
         )}+*+100000+%2F+${base_M}%29%29+*+%283+%2F+400%29>), [${formatted_higher_bound}](<https://www.google.com/search?q=%28210000+-+%28${parseFloat(
           score - 0.5
-        )}+*+100000+%2F+${base_M}%29%29+*+%283+%2F+400%29>))\n  - Margin of Error (Seconds): ± [${formatted_error_range}](<https://www.google.com/search?q=%280.5+*+100000+%2F+${base_M}%29+*+%283+%2F+400%29>)\n  - M value: ${base_M}`;
+        )}+*+100000+%2F+${base_M}%29%29+*+%283+%2F+400%29>)]\n  - Margin of Error (Seconds): ± [${formatted_error_range}](<https://www.google.com/search?q=%280.5+*+100000+%2F+${base_M}%29+*+%283+%2F+400%29>)\n  - M value: ${base_M}`;
         if (command === "!time") {
           result_array.push(formatted_result);
           if (


### PR DESCRIPTION
- SCORE: 204667
  - **Actual Time shown on Rating Screen**: 40.xxx
  - Original Time Calc: [0:39.997](<https://www.google.com/search?q=%28210000+-+%28204667+*+100000+%2F+100000%29%29+*+%283+%2F+400%29>)
    - Time Calc Error Range: ([0:39.993](<https://www.google.com/search?q=%28210000+-+%28204667.5+*+100000+%2F+100000%29%29+*+%283+%2F+400%29>), [0:40.001](<https://www.google.com/search?q=%28210000+-+%28204666.5+*+100000+%2F+100000%29%29+*+%283+%2F+400%29>)]
    - Margin of Error (Seconds): ± [0.00375](<https://www.google.com/search?q=%280.5+*+100000+%2F+100000%29+*+%283+%2F+400%29>)
    - M value: 100000

In the above example (baseline score of 204667), it is presumed that a score of 204667.5 rounds to the next score value (204668), but that 20466.5 rounds to 204667.

In other words, the lower **score** on the error bound is inclusive, while the higher **score** on the error bound is exclusive

Since a score of 20466.5 results in the higher bound [0:40.001](<https://www.google.com/search?q=%28210000+-+%28204666.5+*+100000+%2F+100000%29%29+*+%283+%2F+400%29>), it follows that the higher **time** on the error bound is inclusive, while the lower **time** on the error bound is exclusive.